### PR TITLE
pytest-flake8の挙動がおかしかったので普通のflake8にもどしてflake8-junit-reportをつかう

### DIFF
--- a/beproudbot/plugins/alias.py
+++ b/beproudbot/plugins/alias.py
@@ -1,4 +1,5 @@
 from prettytable import PrettyTable
+
 from slackbot.bot import respond_to
 from utils.slack import get_user_name, get_slack_id_by_name
 from db import Session

--- a/beproudbot/plugins/alias_models.py
+++ b/beproudbot/plugins/alias_models.py
@@ -1,5 +1,7 @@
 import datetime
+
 from sqlalchemy import Column, Integer, Unicode, DateTime
+
 from db import Base
 
 

--- a/beproudbot/plugins/alias_models.py
+++ b/beproudbot/plugins/alias_models.py
@@ -1,7 +1,5 @@
 import datetime
-
 from sqlalchemy import Column, Integer, Unicode, DateTime
-
 from db import Base
 
 

--- a/beproudbot/plugins/cleaning_models.py
+++ b/beproudbot/plugins/cleaning_models.py
@@ -1,5 +1,7 @@
 import datetime
+
 from sqlalchemy import Column, Integer, Unicode, DateTime
+
 from db import Base
 
 

--- a/beproudbot/plugins/create_models.py
+++ b/beproudbot/plugins/create_models.py
@@ -1,6 +1,8 @@
 import datetime
+
 from sqlalchemy import Column, Integer, Unicode, DateTime, ForeignKey
 from sqlalchemy.orm import relation
+
 from db import Base
 
 

--- a/beproudbot/plugins/kintai_models.py
+++ b/beproudbot/plugins/kintai_models.py
@@ -1,5 +1,7 @@
 import datetime
+
 from sqlalchemy import Column, Integer, Unicode, DateTime, Boolean
+
 from db import Base
 
 

--- a/beproudbot/plugins/kudo_models.py
+++ b/beproudbot/plugins/kudo_models.py
@@ -1,5 +1,7 @@
 import datetime
+
 from sqlalchemy import Column, Integer, Unicode, DateTime, UniqueConstraint
+
 from db import Base
 
 

--- a/beproudbot/plugins/misc.py
+++ b/beproudbot/plugins/misc.py
@@ -1,4 +1,5 @@
 import random
+
 from slackbot.bot import respond_to
 
 

--- a/beproudbot/plugins/redbull_models.py
+++ b/beproudbot/plugins/redbull_models.py
@@ -1,5 +1,7 @@
 import datetime
+
 from sqlalchemy import Column, Integer, Unicode, DateTime
+
 from db import Base
 
 

--- a/beproudbot/plugins/thx_models.py
+++ b/beproudbot/plugins/thx_models.py
@@ -1,5 +1,7 @@
 import datetime
+
 from sqlalchemy import Column, Integer, Unicode, DateTime
+
 from db import Base
 
 

--- a/beproudbot/plugins/water.py
+++ b/beproudbot/plugins/water.py
@@ -1,7 +1,7 @@
 import datetime
+
 from slackbot.bot import respond_to
 from sqlalchemy import func, case
-
 
 from db import Session
 from beproudbot.plugins.water_models import WaterHistory

--- a/beproudbot/plugins/water_models.py
+++ b/beproudbot/plugins/water_models.py
@@ -1,5 +1,7 @@
 import datetime
+
 from sqlalchemy import Column, Integer, Unicode, DateTime
+
 from db import Base
 
 

--- a/circle.yml
+++ b/circle.yml
@@ -12,15 +12,16 @@ machine:
 
 dependencies:
   override:
-    - pip install -U pip setuptools tox
+    - pip install -U pip setuptools tox flake8_junit_report
 
   cache_directories:
     - "~/.cache/pip"
 
 test:
-  override:
-    - tox -e py35 -- --junitxml=junit.xml
-    - tox -e flake8 -- --junitxml=flake8.xml
-  post:
+  pre:
     - mkdir -p $CIRCLE_TEST_REPORTS/pytest
-    - mv {junit,flake8}.xml $CIRCLE_TEST_REPORTS/pytest/
+  override:
+    - tox -e py35 -- --junitxml=$CIRCLE_TEST_REPORTS/pytest/py35.xml
+    - tox -e flake8_ci
+  post:
+    - flake8_junit flake8.txt $CIRCLE_TEST_REPORTS/pytest/flake8.xml

--- a/circle.yml
+++ b/circle.yml
@@ -21,8 +21,7 @@ compile:
   pre:
     - mkdir -p $CIRCLE_TEST_REPORTS/flake8
   override:
-    - tox -e flake8_ci;
-    - flake8_junit flake8.txt $CIRCLE_TEST_REPORTS/flake8/flake8.xml
+    - tox -e flake8_ci || flake8_junit flake8.txt $CIRCLE_TEST_REPORTS/flake8/flake8.xml
 
 test:
   pre:

--- a/circle.yml
+++ b/circle.yml
@@ -18,12 +18,9 @@ dependencies:
   cache_directories:
     - "~/.cache/pip"
 
-compile:
-  override:
-    - tox -e flake8_ci
-  post:
-    - flake8_junit flake8.txt $CIRCLE_TEST_REPORTS/pytest/flake8.xml
-
 test:
   override:
+    - tox -e flake8_ci
     - tox -e py35 -- --junitxml=$CIRCLE_TEST_REPORTS/pytest/py35.xml
+  post:
+    - flake8_junit flake8.txt $CIRCLE_TEST_REPORTS/pytest/flake8.xml

--- a/circle.yml
+++ b/circle.yml
@@ -17,14 +17,11 @@ dependencies:
   cache_directories:
     - "~/.cache/pip"
 
-compile:
-  pre:
-    - mkdir -p $CIRCLE_TEST_REPORTS/flake8
-  override:
-    - tox -e flake8_ci || flake8_junit flake8.txt $CIRCLE_TEST_REPORTS/flake8/flake8.xml
-
 test:
   pre:
-    - mkdir -p $CIRCLE_TEST_REPORTS/pytest
+    - mkdir -p $CIRCLE_TEST_REPORTS/{pytest,flake8}
   override:
     - tox -e py35 -- --junitxml=$CIRCLE_TEST_REPORTS/pytest/py35.xml
+    - tox -e flake8_ci
+  post:
+    - flake8_junit flake8.txt $CIRCLE_TEST_REPORTS/flake8/flake8.xml

--- a/circle.yml
+++ b/circle.yml
@@ -18,9 +18,10 @@ dependencies:
   cache_directories:
     - "~/.cache/pip"
 
+compile:
+  override:
+    - tox -e flake8_ci; RET=$?; flake8_junit flake8.txt $CIRCLE_TEST_REPORTS/pytest/flake8.xml; exit $RET;
+
 test:
   override:
-    - tox -e flake8_ci
     - tox -e py35 -- --junitxml=$CIRCLE_TEST_REPORTS/pytest/py35.xml
-  post:
-    - flake8_junit flake8.txt $CIRCLE_TEST_REPORTS/pytest/flake8.xml

--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,7 @@ machine:
     # https://discuss.circleci.com/t/speed-up-python-3-5-1-builds/1760/12
     - wget https://s3.amazonaws.com/circle-downloads/circle-pyenv-python-3.5.1_1.0_amd64.deb
     - sudo dpkg -i circle-pyenv-python-3.5.1_1.0_amd64.deb
+    - mkdir -p $CIRCLE_TEST_REPORTS/pytest
   python:
     version: 3.5.1
 
@@ -17,11 +18,12 @@ dependencies:
   cache_directories:
     - "~/.cache/pip"
 
-test:
-  pre:
-    - mkdir -p $CIRCLE_TEST_REPORTS/pytest
+compile:
   override:
-    - tox -e py35 -- --junitxml=$CIRCLE_TEST_REPORTS/pytest/py35.xml
     - tox -e flake8_ci
   post:
     - flake8_junit flake8.txt $CIRCLE_TEST_REPORTS/pytest/flake8.xml
+
+test:
+  override:
+    - tox -e py35 -- --junitxml=$CIRCLE_TEST_REPORTS/pytest/py35.xml

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,6 @@ machine:
     # https://discuss.circleci.com/t/speed-up-python-3-5-1-builds/1760/12
     - wget https://s3.amazonaws.com/circle-downloads/circle-pyenv-python-3.5.1_1.0_amd64.deb
     - sudo dpkg -i circle-pyenv-python-3.5.1_1.0_amd64.deb
-    - mkdir -p $CIRCLE_TEST_REPORTS/pytest
   python:
     version: 3.5.1
 
@@ -19,9 +18,14 @@ dependencies:
     - "~/.cache/pip"
 
 compile:
+  pre:
+    - mkdir -p $CIRCLE_TEST_REPORTS/flake8
   override:
-    - tox -e flake8_ci; RET=$?; flake8_junit flake8.txt $CIRCLE_TEST_REPORTS/pytest/flake8.xml; exit $RET;
+    - tox -e flake8_ci;
+    - flake8_junit flake8.txt $CIRCLE_TEST_REPORTS/flake8/flake8.xml
 
 test:
+  pre:
+    - mkdir -p $CIRCLE_TEST_REPORTS/pytest
   override:
     - tox -e py35 -- --junitxml=$CIRCLE_TEST_REPORTS/pytest/py35.xml

--- a/tox.ini
+++ b/tox.ini
@@ -13,22 +13,31 @@ commands = pytest {posargs}
 
 [testenv:flake8]
 deps =
-    pytest
-    pytest-flake8
     flake8
     flake8-blind-except
     flake8-import-order
     mccabe
     radon
-commands = pytest beproudbot utils --flake8 {posargs}
+
+commands = flake8 beproudbot utils
+
+[testenv:flake8_ci]
+deps = {[testenv:flake8]deps}
+commands = flake8 \
+    --exit-zero \
+    --output-file={toxinidir}/flake8.txt \
+    beproudbot utils
 
 [pytest]
 testpaths = tests
 
-flake8-max-line-length = 100
-flake8-max-complexity = 10
-flake8-radon-max-cc = 10
-flake8-import-order-style = google
-flake8-ignore = I100
-                I101
-                I201
+[flake8]
+max-line-length = 100
+max-complexity = 10
+radon-max-cc = 10
+import-order-style = google
+ignore =
+    # I100: Import statements are in the wrong order.
+    I100,
+    # I101: Imported names are in the wrong order.
+    I101

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,6 @@ commands = flake8 beproudbot utils
 [testenv:flake8_ci]
 deps = {[testenv:flake8]deps}
 commands = flake8 \
-    --exit-zero \
     --output-file={toxinidir}/flake8.txt \
     beproudbot utils
 

--- a/utils/alias.py
+++ b/utils/alias.py
@@ -1,5 +1,6 @@
-from .slack import get_slack_id_by_name
 from beproudbot.plugins.alias_models import UserAliasName
+
+from .slack import get_slack_id_by_name
 
 
 def get_slack_id(session, user_name):


### PR DESCRIPTION
チケットURL

- https://github.com/beproud/beproudbot/issues/51

このレビューで確認してほしい点

- [ ] https://circleci.com/gh/beproud/beproudbot/47 circleci画面への出方はこんな感じ
- [ ] `I201: Missing newline between sections or imports. ` を改めてチェックする様になったこと
- [ ] そのために修正した `import` 部分の差分に違和感ないか

  - ざっくり `標準ライブラリ > 外部パッケージ > 内部パッケージ > 相対インポート` の順にして間に空行をいれればエラーにならない
- [ ] あとで `I201` エラーでたときになんでエラーになるんだこれムカつく！！ってならない
