### PR TITLE
[WIP] refs #96「MySQL server has gone away」が発生する

### DIFF
--- a/src/alembic/conf.ini
+++ b/src/alembic/conf.ini
@@ -5,6 +5,7 @@
 script_location = alembic/migrations
 pool_size = 20
 pool_pre_ping = True
+pool_recycle = 28800
 
 # template used to generate migration files
 # file_template = %%(rev)s_%%(slug)s


### PR DESCRIPTION
チケットURL

- #96 

このレビューで確認してほしい点

- [ ] Mysqlのデフォルト値を利用してるけど、これはEnvから拾えば良いかな？
- [ ] `pool_pre_ping` はもう設定してあるのでrecycle設定入れても意味ないかも

レビューチェックリスト

- [ ] C2 体を表す名前の公理：あらかじめ決められている以外の汎用的な名前のモジュールを作らない
- [ ] C3 汎用名のモジュール内に長々と具体的処理を書かない
- [ ] C4 単純な処理の長さで分割しない
- [ ] C5 引数の数を減らす
- [ ] C6 パッケージ間で共通した定数を作らない
- [ ] C7 継承の利用を最小限にする
- [ ] C8 親クラスのテストを子クラスでも実行すること
- [ ] C9 オーバーライドを減らす
- [ ] C10 継承やオーバーライドを明示する
