### PR TITLE
#128 haro サーバーを Ubuntu18.04 に upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
             python3 -m venv venv
             source ./venv/bin/activate
             pip install -U pip setuptools tox
-            tox -repy36,flake8_ci
+            tox -epy36,flake8_ci
       - save_cache:
           paths:
             - ./venv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
             python3 -m venv venv
             source ./venv/bin/activate
             pip install -U pip setuptools tox
-            tox -epy36,flake8_ci
+            tox -repy36,flake8_ci
       - save_cache:
           paths:
             - ./venv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.5
+      - image: circleci/python:3.6
     steps:
       - checkout
       # Download and cache dependencies
@@ -17,7 +17,7 @@ jobs:
             python3 -m venv venv
             source ./venv/bin/activate
             pip install -U pip setuptools tox
-            tox -epy35,flake8_ci
+            tox -epy36,flake8_ci
       - save_cache:
           paths:
             - ./venv

--- a/README.md
+++ b/README.md
@@ -111,16 +111,6 @@ $ su - beproud
 パスワード: (いつものあれ)
 $ sudo -iH
 
-# haro リポジトリから最新の master を pull する
-$ cd beproudbot/deployment
-$ git pull
-
-# ※ライブラリ更新が必要な場合のみ※
-# 仮装環境を有効化
-$ source /home/haro/venv/bin/activate
-# ライブラリを更新
-$ pip install -r /home/haro/beproudbot/src/requirements.txt
-
 # デプロイ実行
 $ cd beproudbot/deployment
 $ ~/venv_ansible/bin/ansible-playbook -i hosts --connection local site.yml --tags=deploy

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Haro is [slackbot](https://github.com/lins05/slackbot "lins05/slackbot: A chat b
 
 ### Requirements
 
-- Python 3.5.2 or later.
+- Python 3.6.9 or later.
 
 ```bash
 $ python3 -m venv env

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ $ sudo -iH
 $ cd beproudbot/deployment
 $ ~/venv_ansible/bin/ansible-playbook -i hosts --connection local site.yml --tags=deploy
 # デプロイ実行 (上記の venv がない場合)
-$ /home/altnight/venv_ansible/bin/ansible-playbook -i hosts --connection local site.yml --tags deploy -e "use_local_mysql_server=false"
+$ /home/altnight/venv_ansible/bin/ansible-playbook -i hosts --connection local site.yml --tags deploy
 
 # `git_version` でブランチ/タグ/リビジョンを指定することができます
 $ (cd beproudbot/deployment && ~/venv_ansible/bin/ansible-playbook -i hosts --connection local site.yml --tags=deploy -e "git_version=branch_name")

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "shell", privileged: false, inline: <<-SHELL
     sudo apt update -y
-    sudo apt install -y build-essential python3 python3-dev libssl-dev libffi-dev python3-pip aptitude  python3-venv
+    sudo apt install -y build-essential python3 python3-dev libssl-dev libffi-dev python3-pip aptitude
     sudo pip3 install -U pip
     sudo pip3 install virtualenv
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,8 +2,8 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "bento/ubuntu-16.04"
-  config.vm.box_url = "https://atlas.hashicorp.com/bento/boxes/ubuntu-16.04"
+  config.vm.box = "bento/ubuntu-18.04"
+  config.vm.box_url = "https://vagrantcloud.com/bento/boxes/ubuntu-18.04/versions/202008.16.0/providers/virtualbox.box"
 
   if ENV['VAGRANT_BOOT'].nil?
     config.vm.provider "virtualbox" do |vm|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "shell", privileged: false, inline: <<-SHELL
     sudo apt update -y
-    sudo apt install -y build-essential python3 python3-dev libssl-dev libffi-dev python3-pip aptitude
+    sudo apt install -y build-essential python3 python3-dev libssl-dev libffi-dev python3-pip aptitude  python3-venv
     sudo pip3 install -U pip
     sudo pip3 install virtualenv
 

--- a/deployment/roles/haro/tasks/main.yml
+++ b/deployment/roles/haro/tasks/main.yml
@@ -57,7 +57,7 @@
 # 関連プロセスの再起動
 - name: "restart {{ APP_NAME }}"
   systemd:
-   state: restarted
-   daemon_reload: yes
-   name: "{{ APP_NAME }}"
+    state: restarted
+    daemon_reload: yes
+    name: "{{ APP_NAME }}"
   tags: [deploy]

--- a/deployment/roles/haro/tasks/main.yml
+++ b/deployment/roles/haro/tasks/main.yml
@@ -9,6 +9,8 @@
 - name: update pip
   command: pip3 install -U pip
 - name: install virtualenv
+  # Ubuntu の venv は挙動がおかしい場合があるため、
+  # haro の仮想環境は virtualenv で作成する
   pip:
     name: virtualenv
 

--- a/tox.ini
+++ b/tox.ini
@@ -34,12 +34,15 @@ deps =
     mccabe
     radon
 
+basepython = python3.6
 commands = flake8 src/haro
 
 [testenv:flake8_ci]
 deps =
     {[testenv:flake8]deps}
     flake8_formatter_junit_xml
+
+basepython = python3.6
 commands = flake8 src/haro --output-file={toxinidir}/test-results/flake8.xml --format junit-xml
 
 [pytest]

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,7 @@ deps =
     flake8==3.5
     flake8-blind-except
     flake8-import-order==0.14
+    flake8_polyfill
     mccabe
     radon
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, flake8
+envlist = py36, flake8
 skipsdist = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
 
 commands = pytest {posargs}
 
-[testenv:py35]
+[testenv:py36]
 commands = pytest {posargs} \
            --junitxml={toxinidir}/test-results/pytest.xml
 


### PR DESCRIPTION
# チケットURL

- #128

# 変更点

haro 本番サーバーの Ubuntu を18.04 にアップグレードしたのに合わせて、更新したほうが良さそうな点を更新しました。

* [x] Vagrantfile を本番環境に合わせて更新
  * Ubuntu の box を 18.04 に更新
    * fumi23 環境で `vagrant up` して動作確認済みです 
  * 本番環境に追加した `python3-venv` は、ansible, virtualenv で構築/デプロイする限りはそもそも使う場面がないので、入れるのをやめました。 (現在の本番環境がちょっとイレギュラーな状態になっている、という捉え方が正しいかな、と... すみません)
* [x] READEME の Requirements の Python バージョンを 3.6.9 に更新  (本番環境を up したので合わせるため)
  * その他、前回追加したけれど良くみたらいらなかったデプロイ手順を削除するなどしました

* [x] tox.ini の Pythonバージョンを 3.6 に更新
* [x] circleci のイメージもPythonバージョンを 3.6 に更新

※ Dockerfile は修正していません (経緯: https://github.com/beproud/beproudbot/issues/128#issuecomment-689999659)

# このレビューで確認してほしい点

- [x] Vagrantfile の Ubuntu が 18.04 に更新できていること。
- [x] 必要な箇所の Python バージョンが 3.6 に更新できていること。
- [x] その他、バージョンアップにより変更が必要な点を更新し忘れていたら教えて下さい。

# レビューチェックリスト

- 該当なし
