### PR TITLE
#87 python3.8 対応

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.8
     steps:
       - checkout
       # Download and cache dependencies
@@ -17,7 +17,7 @@ jobs:
             python3 -m venv venv
             source ./venv/bin/activate
             pip install -U pip setuptools tox
-            tox -epy36,flake8_ci
+            tox -epy38,flake8_ci
       - save_cache:
           paths:
             - ./venv

--- a/deployment/roles/haro/defaults/main.yml
+++ b/deployment/roles/haro/defaults/main.yml
@@ -4,6 +4,7 @@ SYSTEMD_SERVICE_FILE: "{{ APP_NAME }}.service"
 ALEMBIC_CONF_PATH: "{{ REPOSITORY_PATH }}/src/alembic/conf.ini"
 REPOSITORY_URL: "https://github.com/beproud/beproudbot.git"
 ENVIRONMENT_FILE_PATH: "{{ REPOSITORY_PATH }}/.env"
+HARO_PYTHON_VERSION: "python3.8"
 
 local_repository_path: /home/vagrant/beproudbot
 git_version: master

--- a/deployment/roles/haro/defaults/main.yml
+++ b/deployment/roles/haro/defaults/main.yml
@@ -4,7 +4,7 @@ SYSTEMD_SERVICE_FILE: "{{ APP_NAME }}.service"
 ALEMBIC_CONF_PATH: "{{ REPOSITORY_PATH }}/src/alembic/conf.ini"
 REPOSITORY_URL: "https://github.com/beproud/beproudbot.git"
 ENVIRONMENT_FILE_PATH: "{{ REPOSITORY_PATH }}/.env"
-HARO_PYTHON_VERSION: "python3.8"
+HARO_PYTHON_VERSION: "3.8"
 
 local_repository_path: /home/vagrant/beproudbot
 git_version: master

--- a/deployment/roles/haro/tasks/main.yml
+++ b/deployment/roles/haro/tasks/main.yml
@@ -8,7 +8,7 @@
     - python3-pip
 - name: install python that haro works
   apt:
-    name: "{{ HARO_PYTHON_VERSION }}"
+    name: "python{{ HARO_PYTHON_VERSION }}"
 - name: update pip
   command: pip3 install -U pip
 - name: install virtualenv
@@ -46,7 +46,7 @@
   pip:
     requirements: "{{ REPOSITORY_PATH }}/src/requirements.txt"
     virtualenv: "{{ VIRTUALENV_PATH }}"
-    virtualenv_python: "{{ HARO_PYTHON_VERSION }}"
+    virtualenv_python: "python{{ HARO_PYTHON_VERSION }}"
   tags: [deploy]
 
 # マイグレーション

--- a/deployment/roles/haro/tasks/main.yml
+++ b/deployment/roles/haro/tasks/main.yml
@@ -6,6 +6,9 @@
     name: "{{ item }}"
   with_items:
     - python3-pip
+- name: install python that haro works
+  apt:
+    name: "{{ HARO_PYTHON_VERSION }}"
 - name: update pip
   command: pip3 install -U pip
 - name: install virtualenv
@@ -43,6 +46,7 @@
   pip:
     requirements: "{{ REPOSITORY_PATH }}/src/requirements.txt"
     virtualenv: "{{ VIRTUALENV_PATH }}"
+    virtualenv_python: "{{ HARO_PYTHON_VERSION }}"
   tags: [deploy]
 
 # マイグレーション

--- a/src/constraints.txt
+++ b/src/constraints.txt
@@ -12,11 +12,11 @@ prettytable==0.7.2
 PyMySQL==0.7.11
 python-dateutil==2.6.1
 python-editor==1.0.3
-requests==2.18.4
+requests==2.24.0
 six==1.11.0
 slackbot==1.0.0
 slacker==0.14.0
-SQLAlchemy==1.2.2
+SQLAlchemy==1.3.19
 urllib3==1.22
 websocket-client==0.44.0
 python-redmine==2.0.2

--- a/src/constraints.txt
+++ b/src/constraints.txt
@@ -7,7 +7,7 @@ idna==2.6
 kml2geojson==4.0.2
 Mako==1.0.7
 MarkupSafe==1.1.1
-Pillow==5.2.0
+Pillow==7.2.0
 prettytable==0.7.2
 PyMySQL==0.7.11
 python-dateutil==2.6.1

--- a/src/haro/alias.py
+++ b/src/haro/alias.py
@@ -1,5 +1,4 @@
 from haro.plugins.alias_models import UserAliasName
-
 from haro.slack import get_slack_id_by_name
 
 

--- a/src/haro/plugins/alias.py
+++ b/src/haro/plugins/alias.py
@@ -1,6 +1,5 @@
 from prettytable import PrettyTable
 from slackbot.bot import respond_to
-
 from db import Session
 from haro.botmessage import botsend
 from haro.plugins.alias_models import UserAliasName

--- a/src/haro/plugins/alias.py
+++ b/src/haro/plugins/alias.py
@@ -15,8 +15,8 @@ HELP = """
 """
 
 
-@respond_to('^alias\s+show$')
-@respond_to('^alias\s+show\s+(\S+)$')
+@respond_to(r'^alias\s+show$')
+@respond_to(r'^alias\s+show\s+(\S+)$')
 def show_user_alias_name(message, user_name=None):
     """ユーザーのエイリアス名一覧を表示する
 
@@ -44,8 +44,8 @@ def show_user_alias_name(message, user_name=None):
     botsend(message, '```{}```'.format(pt))
 
 
-@respond_to('^alias\s+add\s+(\S+)$')
-@respond_to('^alias\s+add\s+(\S+)\s+(\S+)$')
+@respond_to(r'^alias\s+add\s+(\S+)$')
+@respond_to(r'^alias\s+add\s+(\S+)\s+(\S+)$')
 def alias_name(message, user_name, alias_name=None):
     """指定したユーザにエイリアス名を紐付ける
 
@@ -85,8 +85,8 @@ def alias_name(message, user_name, alias_name=None):
     botsend(message, '{}のエイリアス名に `{}` を追加しました'.format(user_name, alias_name))
 
 
-@respond_to('^alias\s+del\s+(\S+)$')
-@respond_to('^alias\s+del\s+(\S+)\s+(\S+)$')
+@respond_to(r'^alias\s+del\s+(\S+)$')
+@respond_to(r'^alias\s+del\s+(\S+)\s+(\S+)$')
 def unalias_name(message, user_name, alias_name=None):
     """ユーザーに紐づくエイリアス名を削除する
 
@@ -123,7 +123,7 @@ def unalias_name(message, user_name, alias_name=None):
         botsend(message, '{}のエイリアス名 `{}` は登録されていません'.format(user_name, alias_name))
 
 
-@respond_to('^alias\s+help$')
+@respond_to(r'^alias\s+help$')
 def show_help_alias_commands(message):
     """Userコマンドのhelpを表示
 

--- a/src/haro/plugins/alias_models.py
+++ b/src/haro/plugins/alias_models.py
@@ -1,7 +1,6 @@
 import datetime
 
 from sqlalchemy import Column, Integer, Unicode, DateTime
-
 from db import Base
 
 

--- a/src/haro/plugins/amesh.py
+++ b/src/haro/plugins/amesh.py
@@ -7,7 +7,6 @@ from datetime import datetime
 
 import requests
 from PIL import Image
-
 from haro.botmessage import botsend
 from slackbot.bot import respond_to
 

--- a/src/haro/plugins/cleaning.py
+++ b/src/haro/plugins/cleaning.py
@@ -40,7 +40,7 @@ FORMATTED_CLEANING_TASKS = ('掃除でやることリスト\n' +
 DAY_OF_WEEK = '月火水木金'
 
 
-@respond_to('^cleaning\s+help$')
+@respond_to(r'^cleaning\s+help$')
 def show_help_cleaning_commands(message):
     """Cleaningコマンドのhelpを表示
 
@@ -49,7 +49,7 @@ def show_help_cleaning_commands(message):
     botsend(message, HELP)
 
 
-@respond_to('^cleaning\s+task$')
+@respond_to(r'^cleaning\s+task$')
 def show_cleaning_task(message):
     """掃除作業一覧を表示
 
@@ -58,7 +58,7 @@ def show_cleaning_task(message):
     botsend(message, FORMATTED_CLEANING_TASKS)
 
 
-@respond_to('^cleaning\s+list$')
+@respond_to(r'^cleaning\s+list$')
 def show_cleaning_list(message):
     """掃除当番の一覧を表示する
 
@@ -80,7 +80,7 @@ def show_cleaning_list(message):
     botsend(message, '```{}```'.format(pt))
 
 
-@respond_to('^cleaning\s+today$')
+@respond_to(r'^cleaning\s+today$')
 def show_today_cleaning_list(message):
     """今日の掃除当番を表示する
 
@@ -94,7 +94,7 @@ def show_today_cleaning_list(message):
     botsend(message, '今日の掃除当番は{}です'.format('、'.join(users)))
 
 
-@respond_to('^cleaning\s+add\s+(\S+)\s+(\S+)$')
+@respond_to(r'^cleaning\s+add\s+(\S+)\s+(\S+)$')
 def cleaning_add(message, user_name, day_of_week):
     """指定した曜日の掃除当番にユーザーを追加する
 
@@ -122,7 +122,7 @@ def cleaning_add(message, user_name, day_of_week):
     botsend(message, '{}を{}曜日の掃除当番に登録しました'.format(user_name, day_of_week))
 
 
-@respond_to('^cleaning\s+del\s+(\S+)\s+(\S+)$')
+@respond_to(r'^cleaning\s+del\s+(\S+)\s+(\S+)$')
 def cleaning_del(message, user_name, day_of_week):
     """指定した曜日の掃除当番からユーザーを削除する
 
@@ -153,7 +153,7 @@ def cleaning_del(message, user_name, day_of_week):
         botsend(message, '{}は{}曜日の掃除当番に登録されていません'.format(user_name, day_of_week))
 
 
-@respond_to('^cleaning\s+swap\s+(\S+)\s+(\S+)$')
+@respond_to(r'^cleaning\s+swap\s+(\S+)\s+(\S+)$')
 def cleaning_swap(message, user_name1, user_name2):
     """登録された掃除当番のユーザーの掃除曜日を入れ替える
 
@@ -196,7 +196,7 @@ def cleaning_swap(message, user_name1, user_name2):
     botsend(message, '{}と{}の掃除当番を交換しました'.format(user_name1, user_name2))
 
 
-@respond_to('^cleaning\s+move\s+(\S+)\s+(\S+)$')
+@respond_to(r'^cleaning\s+move\s+(\S+)\s+(\S+)$')
 def cleaning_move(message, user_name, day_of_week):
     """登録された掃除当番のユーザーの掃除曜日を移動させる
 

--- a/src/haro/plugins/cleaning.py
+++ b/src/haro/plugins/cleaning.py
@@ -3,7 +3,6 @@ from collections import OrderedDict
 
 from prettytable import PrettyTable
 from slackbot.bot import respond_to
-
 from db import Session
 from haro.alias import get_slack_id
 from haro.botmessage import botsend

--- a/src/haro/plugins/cleaning.py
+++ b/src/haro/plugins/cleaning.py
@@ -33,8 +33,9 @@ CLEANING_TASKS = [
 ]
 
 # 掃除作業を表示用に整形した文字列
-FORMATTED_CLEANING_TASKS = ('掃除でやることリスト\n' +
-                            '\n'.join(['- [] {}'.format(row) for row in CLEANING_TASKS]))
+FORMATTED_CLEANING_TASKS = (
+    '掃除でやることリスト\n' + '\n'.join(['- [] {}'.format(row) for row in CLEANING_TASKS])
+)
 
 DAY_OF_WEEK = '月火水木金'
 

--- a/src/haro/plugins/cleaning.py
+++ b/src/haro/plugins/cleaning.py
@@ -113,7 +113,7 @@ def cleaning_add(message, user_name, day_of_week):
 
     q = s.query(Cleaning).filter(Cleaning.slack_id == slack_id)
     if s.query(q.exists()).scalar():
-        botsend(message, '{}は既に登録されています'.format(user_name, day_of_week))
+        botsend(message, '{}は既に登録されています'.format(user_name))
         return
 
     s.add(Cleaning(slack_id=slack_id, day_of_week=DAY_OF_WEEK.index(day_of_week)))

--- a/src/haro/plugins/cleaning_models.py
+++ b/src/haro/plugins/cleaning_models.py
@@ -1,7 +1,6 @@
 import datetime
 
 from sqlalchemy import Column, Integer, Unicode, DateTime
-
 from db import Base
 
 

--- a/src/haro/plugins/create.py
+++ b/src/haro/plugins/create.py
@@ -35,7 +35,7 @@ def command_patterns(message):
     commands = set()
     for deco in ['respond_to', 'listen_to']:
         for re_compile in message._plugins.commands.get(deco):
-            commands.add(re_compile.pattern.split('\s')[0].lstrip('^').rstrip('$'))
+            commands.add(re_compile.pattern.split('\\s')[0].lstrip('^').rstrip('$'))
     return commands
 
 
@@ -147,7 +147,7 @@ class ReturnTermCommandValidator(BaseCommandValidator):
         return self.get_command(command_name)
 
 
-@respond_to('^create\s+add\s+(\S+)$')
+@respond_to(r'^create\s+add\s+(\S+)$')
 @register_arg_validator(AddCommandValidator)
 def add_command(message, command_name):
     """新たにコマンドを作成する
@@ -162,7 +162,7 @@ def add_command(message, command_name):
     botsend(message, '`${}`コマンドを登録しました'.format(command_name))
 
 
-@respond_to('^create\s+del\s+(\S+)$')
+@respond_to(r'^create\s+del\s+(\S+)$')
 @register_arg_validator(DelCommandValidator, ['command'])
 def del_command(message, command_name, command=None):
     """コマンドを削除する
@@ -176,7 +176,7 @@ def del_command(message, command_name, command=None):
     botsend(message, '`${}`コマンドを削除しました'.format(command_name))
 
 
-@respond_to('^(\S+)$')
+@respond_to(r'^(\S+)$')
 @register_arg_validator(ReturnTermCommandValidator, ['command'])
 def return_term(message, command_name, command=None):
     """コマンドに登録されている語録をランダムに返す
@@ -194,7 +194,7 @@ def return_term(message, command_name, command=None):
             botsend(message, '`${}`コマンドにはまだ語録が登録されていません'.format(command_name))
 
 
-@respond_to('^(\S+)\s+(.+)')
+@respond_to(r'^(\S+)\s+(.+)')
 @register_arg_validator(RunCommandValidator, ['command'])
 def run_command(message, command_name, params, command=None):
     """登録したコマンドに対して各種操作を行う
@@ -347,7 +347,7 @@ def add_term(message, command, word):
         botsend(message, 'コマンド `${}` に「{}」を追加しました'.format(name, word))
 
 
-@respond_to('^create\s+help$')
+@respond_to(r'^create\s+help$')
 def show_help_create_commands(message):
     """createコマンドのhelpを表示
 

--- a/src/haro/plugins/create.py
+++ b/src/haro/plugins/create.py
@@ -244,7 +244,7 @@ def pop_term(message, command):
     term = (s.query(Term)
             .filter(Term.create_command == command.id)
             .filter(Term.creator == message.body['user'])
-            .order_by('-id')
+            .order_by(Term.id.desc())
             .first())
 
     name = command.name

--- a/src/haro/plugins/create.py
+++ b/src/haro/plugins/create.py
@@ -2,7 +2,6 @@ import random
 
 from slackbot.bot import respond_to
 from sqlalchemy.orm import join
-
 from db import Session
 from haro.arg_validator import (
     BaseArgValidator,

--- a/src/haro/plugins/create_models.py
+++ b/src/haro/plugins/create_models.py
@@ -2,7 +2,6 @@ import datetime
 
 from sqlalchemy import Column, Integer, Unicode, DateTime, ForeignKey
 from sqlalchemy.orm import relation
-
 from db import Base
 
 

--- a/src/haro/plugins/kintai.py
+++ b/src/haro/plugins/kintai.py
@@ -42,7 +42,7 @@ def replay_you_did_good_today(message):
     botreply(message, random.choice(messages))
 
 
-@respond_to('^kintai\s+start$')
+@respond_to(r'^kintai\s+start$')
 def register_workon_time(message):
     """出社時刻を記録して挨拶を返すコマンド
 
@@ -53,7 +53,7 @@ def register_workon_time(message):
     botreply(message, '出社時刻を記録しました')
 
 
-@respond_to('^kintai\s+end$')
+@respond_to(r'^kintai\s+end$')
 def register_workoff_time(message):
     """退社時刻を記録して挨拶を返すコマンド
 
@@ -85,7 +85,7 @@ def register_worktime(user_id, is_workon=True):
     s.commit()
 
 
-@respond_to('^kintai\s+show$')
+@respond_to(r'^kintai\s+show$')
 def show_kintai_history(message):
     """直近40日分の勤怠記録を表示します
 
@@ -122,8 +122,8 @@ def show_kintai_history(message):
     botsend(message, '{}の勤怠:\n{}'.format(user_name, '\n'.join(rows)))
 
 
-@respond_to('^kintai\s+csv$')
-@respond_to('^kintai\s+csv\s+(\d{4}/\d{1,2})$')
+@respond_to(r'^kintai\s+csv$')
+@respond_to(r'^kintai\s+csv\s+(\d{4}/\d{1,2})$')
 def show_kintai_history_csv(message, time=None):
     """指定した月の勤怠記録をCSV形式で返す
 
@@ -179,7 +179,7 @@ def show_kintai_history_csv(message, time=None):
                   files={'file': output.getvalue()})
 
 
-@respond_to('^kintai\s+help$')
+@respond_to(r'^kintai\s+help$')
 def show_help_kintai_commands(message):
     """勤怠コマンドのhelpを表示
 

--- a/src/haro/plugins/kintai.py
+++ b/src/haro/plugins/kintai.py
@@ -9,7 +9,6 @@ import requests
 from slackbot import settings
 from slackbot.bot import respond_to, listen_to
 from sqlalchemy import func, Date, cast
-
 from db import Session
 from haro.botmessage import botreply, botsend
 from haro.plugins.kintai_models import KintaiHistory

--- a/src/haro/plugins/kintai_models.py
+++ b/src/haro/plugins/kintai_models.py
@@ -1,7 +1,6 @@
 import datetime
 
 from sqlalchemy import Column, Integer, Unicode, DateTime, Boolean
-
 from db import Base
 
 

--- a/src/haro/plugins/kudo.py
+++ b/src/haro/plugins/kudo.py
@@ -1,6 +1,5 @@
 from slackbot.bot import respond_to, listen_to
 from sqlalchemy import func
-
 from db import Session
 from haro.botmessage import botsend
 from haro.plugins.kudo_models import KudoHistory

--- a/src/haro/plugins/kudo.py
+++ b/src/haro/plugins/kudo.py
@@ -12,7 +12,7 @@ HELP = """
 """
 
 
-@listen_to('^(.*)\s*(?<!\+)\+\+$')
+@listen_to(r'^(.*)\s*(?<!\+)\+\+$')
 def update_kudo(message, names):
     """ 指定された名前に対して ++ する
 
@@ -59,7 +59,7 @@ def update_kudo(message, names):
     botsend(message, '\n'.join(msg))
 
 
-@respond_to('^kudo\s+help$')
+@respond_to(r'^kudo\s+help$')
 def show_help_alias_commands(message):
     """Kudoコマンドのhelpを表示
 

--- a/src/haro/plugins/kudo_models.py
+++ b/src/haro/plugins/kudo_models.py
@@ -1,7 +1,6 @@
 import datetime
 
 from sqlalchemy import Column, Integer, Unicode, DateTime, UniqueConstraint
-
 from db import Base
 
 

--- a/src/haro/plugins/lunch.py
+++ b/src/haro/plugins/lunch.py
@@ -110,8 +110,8 @@ def lunch(keyword, distance=500):  # NOQA: ignore=C901
 
 
 @respond_to('^lunch$')
-@respond_to('^lunch\s+(\S+)$')
-@respond_to('^lunch\s+(\S+)\s+(\d+)$')
+@respond_to(r'^lunch\s+(\S+)$')
+@respond_to(r'^lunch\s+(\S+)\s+(\d+)$')
 def show_lunch(message, keyword=None, distance=500):
     """Lunchコマンドの結果を表示する
 
@@ -127,7 +127,7 @@ def show_lunch(message, keyword=None, distance=500):
     botsend(message, lunch(keyword, distance))
 
 
-@respond_to('^lunch\s+help$')
+@respond_to(r'^lunch\s+help$')
 def show_help_lunch_commands(message):
     """lunchコマンドのhelpを表示
 

--- a/src/haro/plugins/lunch.py
+++ b/src/haro/plugins/lunch.py
@@ -1,8 +1,8 @@
 import re
 import random
+import xml.dom.minidom as md
 
 import requests
-import xml.dom.minidom as md
 import kml2geojson as k2g
 from geopy.distance import vincenty
 from slackbot.bot import respond_to

--- a/src/haro/plugins/lunch.py
+++ b/src/haro/plugins/lunch.py
@@ -6,7 +6,6 @@ import xml.dom.minidom as md
 import kml2geojson as k2g
 from geopy.distance import vincenty
 from slackbot.bot import respond_to
-
 from haro.botmessage import botsend
 
 KML_SOURCE = 'https://www.google.com/maps/d/u/0/kml?hl=en&mid=1J4U-QXOe1Zi_4Lw5UxaL8AriG6M&lid=zubJL41y6fLI.k8KrINTXzJI4&forcekml=1'  # NOQA

--- a/src/haro/plugins/misc.py
+++ b/src/haro/plugins/misc.py
@@ -5,7 +5,7 @@ from slackbot.bot import respond_to
 from haro.botmessage import botsend
 
 
-@respond_to('^shuffle\s+(.*)')
+@respond_to(r'^shuffle\s+(.*)')
 def shuffle(message, words):
     """指定したキーワードをシャッフルして返す
     """
@@ -17,7 +17,7 @@ def shuffle(message, words):
         botsend(message, ' '.join(words))
 
 
-@respond_to('^choice\s+(.*)')
+@respond_to(r'^choice\s+(.*)')
 def choice(message, words):
     """指定したキーワードから一つを選んで返す
     """

--- a/src/haro/plugins/misc.py
+++ b/src/haro/plugins/misc.py
@@ -1,7 +1,6 @@
 import random
 
 from slackbot.bot import respond_to
-
 from haro.botmessage import botsend
 
 

--- a/src/haro/plugins/random.py
+++ b/src/haro/plugins/random.py
@@ -4,7 +4,6 @@ import random
 from slackbot.bot import respond_to
 from slackbot import settings
 import slacker
-
 from haro.botmessage import botsend
 
 

--- a/src/haro/plugins/random.py
+++ b/src/haro/plugins/random.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 @respond_to('^random$')
-@respond_to('^random\s+(active|help)$')
+@respond_to(r'^random\s+(active|help)$')
 def random_command(message, subcommand=None):
     """
     チャンネルにいるメンバーからランダムに一人を選んで返す

--- a/src/haro/plugins/redbull.py
+++ b/src/haro/plugins/redbull.py
@@ -8,7 +8,6 @@ import requests
 from slackbot import settings
 from slackbot.bot import respond_to
 from sqlalchemy import func
-
 from db import Session
 from haro.botmessage import botsend
 from haro.plugins.redbull_models import RedbullHistory

--- a/src/haro/plugins/redbull.py
+++ b/src/haro/plugins/redbull.py
@@ -26,7 +26,7 @@ HELP = """
 """
 
 
-@respond_to('^redbull\s+count$')
+@respond_to(r'^redbull\s+count$')
 def count_redbull_stock(message):
     """現在のRedBullの在庫本数を返すコマンド
 
@@ -40,7 +40,7 @@ def count_redbull_stock(message):
     botsend(message, 'レッドブル残り {} 本'.format(stock_number))
 
 
-@respond_to('^redbull\s+(-?\d+)$')
+@respond_to(r'^redbull\s+(-?\d+)$')
 def manage_redbull_stock(message, delta):
     """RedBullの本数の増減を行うコマンド
 
@@ -63,7 +63,7 @@ def manage_redbull_stock(message, delta):
         botsend(message, 'レッドブルが{}により{}本消費されました'.format(user_name, -delta))
 
 
-@respond_to('^redbull\s+history$')
+@respond_to(r'^redbull\s+history$')
 def show_user_redbull_history(message):
     """RedBullのUserごとの消費履歴を返すコマンド
 
@@ -87,7 +87,7 @@ def show_user_redbull_history(message):
     botsend(message, '{}の消費したレッドブル:\n{}'.format(user_name, ret))
 
 
-@respond_to('^redbull\s+csv$')
+@respond_to(r'^redbull\s+csv$')
 def show_redbull_history_csv(message):
     """RedBullの月単位の消費履歴をCSVに出力する
 
@@ -122,8 +122,8 @@ def show_redbull_history_csv(message):
                   files={'file': output.getvalue()})
 
 
-@respond_to('^redbull\s+clear$')
-@respond_to('^redbull\s+clear\s+(\w+)$')
+@respond_to(r'^redbull\s+clear$')
+@respond_to(r'^redbull\s+clear\s+(\w+)$')
 def clear_redbull_history(message, token=None):
     """RedBullの履歴データを削除するコマンド
 
@@ -151,7 +151,7 @@ def clear_redbull_history(message, token=None):
         botsend(message, 'コマンドが一致しないため履歴をクリアできませんでした')
 
 
-@respond_to('^redbull\s+help$')
+@respond_to(r'^redbull\s+help$')
 def show_help_redbull_commands(message):
     """RedBullコマンドのhelpを表示
 

--- a/src/haro/plugins/redbull_models.py
+++ b/src/haro/plugins/redbull_models.py
@@ -1,7 +1,6 @@
 import datetime
 
 from sqlalchemy import Column, Integer, Unicode, DateTime
-
 from db import Base
 
 

--- a/src/haro/plugins/redmine.py
+++ b/src/haro/plugins/redmine.py
@@ -71,8 +71,8 @@ def show_help_redmine_commands(message):
     botsend(message, HELP)
 
 
-@listen_to(r'issues\/(\d{2,}\#note\-\d+)|issues\/(\d{2,})|[^a-zA-Z/`\n`][t](\d{2,})|^t(\d{2,})')  # NOQA: R701,C901,E501
-def show_ticket_information(message, *ticket_ids):
+@listen_to(r'issues\/(\d{2,}\#note\-\d+)|issues\/(\d{2,})|[^a-zA-Z/`\n`][t](\d{2,})|^t(\d{2,})')
+def show_ticket_information(message, *ticket_ids):  # NOQA: R701, C901
     """Redmineのチケット情報を参照する.
 
     :param message: slackbotの各種パラメータを保持したclass

--- a/src/haro/plugins/redmine.py
+++ b/src/haro/plugins/redmine.py
@@ -51,7 +51,7 @@ def project_channel_from_identifier(api_key, identifier, session):
     except (ForbiddenError, ResourceNotFoundError):
         return None, None
 
-    chan = session.query(ProjectChannel).filter(ProjectChannel.project_id == project.id).\
+    chan = session.query(ProjectChannel).filter(ProjectChannel.project_id == project.id). \
         one_or_none()
     return project, chan
 
@@ -66,14 +66,14 @@ def user_from_message(message, session):
     return user
 
 
-@respond_to('^redmine\s+help$')
+@respond_to(r'^redmine\s+help$')
 def show_help_redmine_commands(message):
     """Redmineコマンドのhelpを表示
     """
     botsend(message, HELP)
 
 
-@listen_to('issues\/(\d{2,}\#note\-\d+)|issues\/(\d{2,})|[^a-zA-Z/`\n`][t](\d{2,})|^t(\d{2,})')  # NOQA: R701,C901,E501
+@listen_to(r'issues\/(\d{2,}\#note\-\d+)|issues\/(\d{2,})|[^a-zA-Z/`\n`][t](\d{2,})|^t(\d{2,})')  # NOQA: R701,C901,E501
 def show_ticket_information(message, *ticket_ids):
     """Redmineのチケット情報を参照する.
 
@@ -109,7 +109,7 @@ def show_ticket_information(message, *ticket_ids):
             return
 
         proj_id = ticket.project.id
-        proj_room = s.query(ProjectChannel).filter(ProjectChannel.project_id == proj_id)\
+        proj_room = s.query(ProjectChannel).filter(ProjectChannel.project_id == proj_id) \
             .one_or_none()
 
         if not proj_room or channel_id not in proj_room.channels.split(','):
@@ -149,7 +149,7 @@ def show_ticket_information(message, *ticket_ids):
         sc.chat.post_message(channel_id, description, as_user=True, thread_ts=res.body['ts'])
 
 
-@respond_to('^redmine\s+key\s+(\S+)$')
+@respond_to(r'^redmine\s+key\s+(\S+)$')
 def register_key(message, api_key):
     s = Session()
 
@@ -173,7 +173,7 @@ def register_key(message, api_key):
     botsend(message, API_KEY_SET)
 
 
-@respond_to('^redmine\s+add\s+([a-zA-Z0-9_-]+)$')
+@respond_to(r'^redmine\s+add\s+([a-zA-Z0-9_-]+)$')
 def register_room(message, project_identifier):
     """RedmineのプロジェクトとSlackチャンネルを繋ぐ.
 
@@ -207,7 +207,7 @@ def register_room(message, project_identifier):
         botsend(message, CHANNEL_ALREADY_REGISTERED)
 
 
-@respond_to('^redmine\s+remove\s+([a-zA-Z0-9_-]+)$')
+@respond_to(r'^redmine\s+remove\s+([a-zA-Z0-9_-]+)$')
 def unregister_room(message, project_identifier):
     s = Session()
 

--- a/src/haro/plugins/redmine.py
+++ b/src/haro/plugins/redmine.py
@@ -1,9 +1,7 @@
 from redminelib import Redmine
 from redminelib.exceptions import ForbiddenError, ResourceNotFoundError
-
 from slackbot.bot import listen_to, respond_to
 from slackbot_settings import REDMINE_URL
-
 from db import Session
 from haro.botmessage import botsend
 from haro.plugins.redmine_models import RedmineUser, ProjectChannel

--- a/src/haro/plugins/redmine_models.py
+++ b/src/haro/plugins/redmine_models.py
@@ -1,5 +1,4 @@
 from sqlalchemy import Column, Integer, Unicode
-
 from db import Base
 
 

--- a/src/haro/plugins/resource.py
+++ b/src/haro/plugins/resource.py
@@ -8,7 +8,6 @@
 import random
 
 from slackbot.bot import respond_to
-
 from db import Session
 from haro.botmessage import botsend
 from haro.plugins.resource_models import Resource

--- a/src/haro/plugins/resource.py
+++ b/src/haro/plugins/resource.py
@@ -22,7 +22,7 @@ COMMANDS = (
 )
 
 
-@respond_to('^status\s+help$')
+@respond_to(r'^status\s+help$')
 def show_help(message):
     """Statusコマンドのhelpを表示
 
@@ -60,7 +60,7 @@ def show_resources(message):
 respond_to('^status$')(show_resources)
 
 
-@respond_to('^status\s+add\s+(\S+)$')
+@respond_to(r'^status\s+add\s+(\S+)$')
 def add_resource(message, name):
     """リソースの追加
 
@@ -84,7 +84,7 @@ def add_resource(message, name):
     show_resources(message)
 
 
-@respond_to('^status\s+(del|delete|rm|remove)\s+(\S+)$')
+@respond_to(r'^status\s+(del|delete|rm|remove)\s+(\S+)$')
 def remove_resource(message, _, name):
     """リソースの削除
 
@@ -105,7 +105,7 @@ def remove_resource(message, _, name):
     show_resources(message)
 
 
-@respond_to('^status\s+(\S+)$')
+@respond_to(r'^status\s+(\S+)$')
 def unset_resource_status(message, name):
     """リソースの設定を初期値に戻す
 
@@ -129,7 +129,7 @@ def unset_resource_status(message, name):
     show_resources(message)
 
 
-@respond_to('^status\s+(\S+)\s+(\S+)$')
+@respond_to(r'^status\s+(\S+)\s+(\S+)$')
 def set_resource_status(message, name, value):
     """リソースの設定
 

--- a/src/haro/plugins/resource_models.py
+++ b/src/haro/plugins/resource_models.py
@@ -1,7 +1,6 @@
 import datetime
 
 from sqlalchemy import Column, Integer, Unicode, DateTime
-
 from db import Base
 
 

--- a/src/haro/plugins/thx.py
+++ b/src/haro/plugins/thx.py
@@ -36,7 +36,7 @@ def find_thx(s, text):
     hint_names = []
     not_matched = []
 
-    thx_matcher = re.compile('(?P<user_names>.+)[ \t\f\v]*(?<!\+)\+\+[ \t\f\v]+(?P<word>.+)',
+    thx_matcher = re.compile(r'(?P<user_names>.+)[ \t\f\v]*(?<!\+)\+\+[ \t\f\v]+(?P<word>.+)',
                              re.MULTILINE)
     for thx in thx_matcher.finditer(text):
         user_names = [x for x in thx.group('user_names').split(' ') if x]
@@ -63,7 +63,7 @@ def find_thx(s, text):
     return word_map_names_dict, hint_names, not_matched
 
 
-@listen_to('.*\s*(?<!\+)\+\+\s+.+')
+@listen_to(r'.*\s*(?<!\+)\+\+\s+.+')
 def update_thx(message):
     """指定したSlackのユーザーにGJを行う
 
@@ -123,8 +123,8 @@ def update_thx(message):
     botsend(message, '\n'.join(msg))
 
 
-@respond_to('^thx\s+from$')
-@respond_to('^thx\s+from\s+(\S+)$')
+@respond_to(r'^thx\s+from$')
+@respond_to(r'^thx\s+from\s+(\S+)$')
 def show_thx_from(message, user_name=None):
     """誰からGJされたか表示します
 
@@ -161,8 +161,8 @@ def show_thx_from(message, user_name=None):
                   files={'file': ("%s_thx.csv" % user_name, output.getvalue(), 'text/csv', )})
 
 
-@respond_to('^thx\s+to$')
-@respond_to('^thx\s+to\s+(\S+)$')
+@respond_to(r'^thx\s+to$')
+@respond_to(r'^thx\s+to\s+(\S+)$')
 def show_thx_to(message, user_name=None):
     """誰にGJしたか表示します
 
@@ -198,7 +198,7 @@ def show_thx_to(message, user_name=None):
                   files={'file': ("%s_thx.csv" % user_name, output.getvalue(), 'text/csv',)})
 
 
-@respond_to('^thx\s+help$')
+@respond_to(r'^thx\s+help$')
 def show_help_thx_commands(message):
     """thxコマンドのhelpを表示
 

--- a/src/haro/plugins/thx.py
+++ b/src/haro/plugins/thx.py
@@ -6,7 +6,6 @@ from io import StringIO
 import requests
 from slackbot import settings
 from slackbot.bot import respond_to, listen_to
-
 from db import Session
 from haro.alias import get_slack_id
 from haro.botmessage import botsend

--- a/src/haro/plugins/thx_models.py
+++ b/src/haro/plugins/thx_models.py
@@ -1,7 +1,6 @@
 import datetime
 
 from sqlalchemy import Column, Integer, Unicode, DateTime
-
 from db import Base
 
 

--- a/src/haro/plugins/uranai.py
+++ b/src/haro/plugins/uranai.py
@@ -30,7 +30,7 @@ def uranai(birthday):
 {content}""".format(**d)
 
 
-@respond_to('^uranai\s+(\d{4})$')
+@respond_to(r'^uranai\s+(\d{4})$')
 def show_uranai_commands(message, birthday):
     """Uranaiコマンドの結果を表示
 

--- a/src/haro/plugins/uranai.py
+++ b/src/haro/plugins/uranai.py
@@ -2,7 +2,6 @@ import datetime
 
 import requests
 from slackbot.bot import respond_to
-
 from haro.botmessage import botsend
 
 

--- a/src/haro/plugins/water.py
+++ b/src/haro/plugins/water.py
@@ -16,7 +16,7 @@ HELP = '''
 '''
 
 
-@respond_to('^water\s+count$')
+@respond_to(r'^water\s+count$')
 def count_water_stock(message):
     """現在の水の在庫本数を返すコマンド
 
@@ -41,7 +41,7 @@ def count_water_stock(message):
         botsend(message, '管理履歴はありません')
 
 
-@respond_to('^water\s+(-?\d+)$')
+@respond_to(r'^water\s+(-?\d+)$')
 def manage_water_stock(message, delta):
     """水の本数の増減を行うコマンド
 
@@ -76,8 +76,8 @@ def manage_water_stock(message, delta):
                 .format(delta, stock_number))
 
 
-@respond_to('^water\s+history$')
-@respond_to('^water\s+history\s+(\d+)$')
+@respond_to(r'^water\s+history$')
+@respond_to(r'^water\s+history\s+(\d+)$')
 def show_water_history(message, limit='10'):
     """水の管理履歴を返すコマンド
 
@@ -104,7 +104,7 @@ def show_water_history(message, limit='10'):
     botsend(message, '水の管理履歴:\n{}'.format(ret))
 
 
-@respond_to('^water\s+help$')
+@respond_to(r'^water\s+help$')
 def show_help_water_commands(message):
     """waterコマンドのhelpを表示
 

--- a/src/haro/plugins/water.py
+++ b/src/haro/plugins/water.py
@@ -2,7 +2,6 @@ import datetime
 
 from slackbot.bot import respond_to
 from sqlalchemy import func, case
-
 from db import Session
 from haro.botmessage import botsend
 from haro.plugins.water_models import WaterHistory

--- a/src/haro/plugins/water_models.py
+++ b/src/haro/plugins/water_models.py
@@ -1,7 +1,6 @@
 import datetime
 
 from sqlalchemy import Column, Integer, Unicode, DateTime
-
 from db import Base
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+from tests.db import DatabaseManager
+
+
+@pytest.fixture(scope='session')
+def test_engine():
+    """Session-wide test database"""
+    from sqlalchemy import create_engine
+    engine = create_engine("sqlite:///test.sqlite")
+    return engine
+
+
+@pytest.fixture()
+def db(test_engine):
+    db = DatabaseManager(test_engine)
+    db.initialize()
+    yield db

--- a/tests/db.py
+++ b/tests/db.py
@@ -1,24 +1,8 @@
 from contextlib import contextmanager
 
-import pytest
 from sqlalchemy.orm import sessionmaker
 
 from db import Base
-
-
-@pytest.fixture(scope='session')
-def test_engine():
-    '''Session-wide test database'''
-    from sqlalchemy import create_engine
-    engine = create_engine("sqlite:///test.sqlite")
-    return engine
-
-
-@pytest.fixture()
-def db():
-    db = DatabaseManager()
-    db.initialize()
-    yield db
 
 
 class DatabaseManager(object):
@@ -28,8 +12,8 @@ class DatabaseManager(object):
     TODO: 本当はget_sql_session()なんかもこちらに寄せた方がよさそう。時間と相談
     """
 
-    def __init__(self):
-        self._engine = test_engine()
+    def __init__(self, test_engine):
+        self._engine = test_engine
         self._session_maker = sessionmaker(bind=self._engine)
 
     def initialize(self):

--- a/tests/test_plugins_kudo.py
+++ b/tests/test_plugins_kudo.py
@@ -1,5 +1,5 @@
 import re
-import imp
+import importlib
 
 from unittest import mock
 import pytest
@@ -10,7 +10,7 @@ class TestUpdateKudo:
     def target_pattern(self):
         with mock.patch('slackbot.bot.listen_to') as mock_listen_to:
             from haro.plugins import kudo
-            imp.reload(kudo)  # ensure applying the decorator
+            importlib.reload(kudo)  # ensure applying the decorator
 
         args, _ = mock_listen_to.call_args
         return re.compile(*args)

--- a/tests/test_plugins_thx.py
+++ b/tests/test_plugins_thx.py
@@ -1,5 +1,5 @@
 import re
-import imp
+import importlib
 from unittest import mock
 
 import pytest
@@ -151,7 +151,7 @@ class TestUpdateThx:
     def target_pattern(self):
         with mock.patch('slackbot.bot.listen_to') as mock_listen_to:
             from haro.plugins import thx
-            imp.reload(thx)  # ensure applying the decorator
+            importlib.reload(thx)  # ensure applying the decorator
 
         args, _ = mock_listen_to.call_args
         return re.compile(*args)

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -41,7 +41,10 @@ def redmine_project(db, project_id=265, channels="C0AGP8QQH,C0AGP8QQZ"):
 
 
 @pytest.fixture
-def slack_message(channel="C0AGP8QQH", user_id="U023BECGF"):
+def slack_message():
+    channel = "C0AGP8QQH"
+    user_id = "U023BECGF"
+
     channel_mock = Mock()
     channel_mock._body = {"id": channel, "name": "test_channel"}
     configure = {
@@ -57,7 +60,20 @@ def slack_message(channel="C0AGP8QQH", user_id="U023BECGF"):
 
 @pytest.fixture
 def no_channel_slack_message():
-    return slack_message(channel="111111111")
+    channel = "111111111"
+    user_id = "U023BECGF"
+
+    channel_mock = Mock()
+    channel_mock._body = {"id": channel, "name": "test_channel"}
+    configure = {
+        "channel": channel_mock
+    }
+
+    message = MagicMock()
+    message.configure_mock(**configure)
+    message.body = {"user": user_id}
+    message.send = Mock()
+    return message
 
 
 def test_invalid_user_response(db, slack_message):

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -12,7 +12,6 @@ from haro.plugins.redmine import (
 )
 
 from tests.factories.redmine import ProjectChannelFactory, RedmineUserFactory
-from tests.db import db
 
 USER_NAME = "Emmanuel Goldstein"
 

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -77,13 +77,13 @@ def no_channel_slack_message():
 
 
 def test_invalid_user_response(db, slack_message):
-    with patch('haro.plugins.redmine.Session', lambda: db.session) as session:
+    with patch('haro.plugins.redmine.Session', lambda: db.session):
         show_ticket_information(slack_message, "1234567")
         assert slack_message.send.called is False
 
 
 def test_no_ticket_permissions_response(db, slack_message, redmine_user, redmine_project):
-    with patch('haro.plugins.redmine.Session', lambda: db.session) as session:
+    with patch('haro.plugins.redmine.Session', lambda: db.session):
         with requests_mock.mock() as response:
             ticket_id = "1234567"
             url = urljoin(REDMINE_URL, "issues/%s.json?key=%s" % (ticket_id, redmine_user.api_key))
@@ -94,7 +94,7 @@ def test_no_ticket_permissions_response(db, slack_message, redmine_user, redmine
 
 
 def test_no_channel_permissions_response(db, slack_message, redmine_user, redmine_project):
-    with patch('haro.plugins.redmine.Session', lambda: db.session) as session:
+    with patch('haro.plugins.redmine.Session', lambda: db.session):
         with requests_mock.mock() as response:
             ticket_id = "1234567"
             channel_name = slack_message.channel._body['name']
@@ -109,7 +109,7 @@ def test_no_channel_permissions_response(db, slack_message, redmine_user, redmin
 
 
 def test_successful_response(db, slack_message, redmine_user, redmine_project):
-    with patch('haro.plugins.redmine.Session', lambda: db.session) as session:
+    with patch('haro.plugins.redmine.Session', lambda: db.session):
 
         client, web_api, chat, post_message, res = Mock(), Mock(), Mock(), Mock(), Mock()
         res.body = {'ts': 123}
@@ -160,7 +160,7 @@ def test_successful_response(db, slack_message, redmine_user, redmine_project):
 
 
 def test_no_channels_no_response(db, no_channel_slack_message, redmine_user, redmine_project):
-    with patch('haro.plugins.redmine.Session', lambda: db.session) as session:
+    with patch('haro.plugins.redmine.Session', lambda: db.session):
         with requests_mock.mock() as response:
             ticket_id = "1234567"
 

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,9 @@ commands = flake8 src/haro --output-file={toxinidir}/test-results/flake8.xml --f
 [pytest]
 testpaths = tests
 
+# https://docs.pytest.org/en/stable/deprecations.html#junit-family-default-value-change-to-xunit2
+junit_family=xunit2
+
 [flake8]
 max-line-length = 100
 max-complexity = 10

--- a/tox.ini
+++ b/tox.ini
@@ -27,9 +27,9 @@ commands = pytest {posargs} \
 
 [testenv:flake8]
 deps =
-    flake8==3.5
+    flake8
     flake8-blind-except
-    flake8-import-order==0.14
+    flake8-import-order
     flake8_polyfill
     mccabe
     radon

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, flake8
+envlist = py38, flake8
 skipsdist = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ setenv =
     SQLALCHEMY_ECHO=true
 
 deps =
-    pytest==3.8.1
+    pytest
     factory_boy
     requests-mock
     -rsrc/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
 
 commands = pytest {posargs}
 
-[testenv:py36]
+[testenv:py38]
 commands = pytest {posargs} \
            --junitxml={toxinidir}/test-results/pytest.xml
 
@@ -34,7 +34,7 @@ deps =
     mccabe
     radon
 
-basepython = python3.6
+basepython = python3.8
 commands = flake8 src/haro
 
 [testenv:flake8_ci]
@@ -42,7 +42,7 @@ deps =
     {[testenv:flake8]deps}
     flake8_formatter_junit_xml
 
-basepython = python3.6
+basepython = python3.8
 commands = flake8 src/haro --output-file={toxinidir}/test-results/flake8.xml --format junit-xml
 
 [pytest]


### PR DESCRIPTION
# チケットURL

- #87
- #205

# 変更点

* haro 動作環境の Python を 3.8 にする
* flake8 3.8 対応

# このレビューで確認してほしい点

- [x] CI が成功していること
- [x] ansible で Python3.8 を install するくだりの書き方が変でないか (ansible はあんまり使い慣れていないです)
- [x] その他 (数が多いので) ざっと見ていただいて違和感のある修正はないか

※ ローカル環境 + #bot-test-fumi23 部屋で動作確認し、すべてのコマンドが正常動作することは確認ずみです 

# レビューチェックリスト

- [x] C2 体を表す名前の公理：あらかじめ決められている以外の汎用的な名前のモジュールを作らない
- [x] C3 汎用名のモジュール内に長々と具体的処理を書かない
- [x] C4 単純な処理の長さで分割しない
- [x] C5 引数の数を減らす
- [x] C6 パッケージ間で共通した定数を作らない
- [x] C7 継承の利用を最小限にする
- [x] C8 親クラスのテストを子クラスでも実行すること
- [x] C9 オーバーライドを減らす
- [x] C10 継承やオーバーライドを明示する
