### PR TITLE
#222 新haro移植済のコマンドに、新haroがインストールされているかをチェックするデコレータを付与

### DIFF
--- a/src/haro/decorators.py
+++ b/src/haro/decorators.py
@@ -18,13 +18,6 @@ def call_when_sls_haro_not_installed(func):
 
     新 haro に移植済なコマンドに付けて、旧 haro と新 haro が一緒に追加されているチャンネルでは、
     新 haro 側のコマンドが優先されるように制御します
-
-    NOTE: デコレータは下から順に呼ばれるので、このデコレータは respond_to, listen_to よりも上に配置すること
-
-    @call_when_sls_haro_not_installed
-    @respond_to("〜")
-    def method(message):
-        pass
     """
     @wraps(func)
     def wrapper(message, *args, **kwargs):

--- a/src/haro/plugins/alias.py
+++ b/src/haro/plugins/alias.py
@@ -2,6 +2,7 @@ from prettytable import PrettyTable
 from slackbot.bot import respond_to
 from db import Session
 from haro.botmessage import botsend
+from haro.decorators import call_when_sls_haro_not_installed
 from haro.plugins.alias_models import UserAliasName
 from haro.slack import get_user_name, get_slack_id_by_name
 
@@ -16,6 +17,7 @@ HELP = """
 
 @respond_to(r'^alias\s+show$')
 @respond_to(r'^alias\s+show\s+(\S+)$')
+@call_when_sls_haro_not_installed
 def show_user_alias_name(message, user_name=None):
     """ユーザーのエイリアス名一覧を表示する
 
@@ -45,6 +47,7 @@ def show_user_alias_name(message, user_name=None):
 
 @respond_to(r'^alias\s+add\s+(\S+)$')
 @respond_to(r'^alias\s+add\s+(\S+)\s+(\S+)$')
+@call_when_sls_haro_not_installed
 def alias_name(message, user_name, alias_name=None):
     """指定したユーザにエイリアス名を紐付ける
 
@@ -86,6 +89,7 @@ def alias_name(message, user_name, alias_name=None):
 
 @respond_to(r'^alias\s+del\s+(\S+)$')
 @respond_to(r'^alias\s+del\s+(\S+)\s+(\S+)$')
+@call_when_sls_haro_not_installed
 def unalias_name(message, user_name, alias_name=None):
     """ユーザーに紐づくエイリアス名を削除する
 
@@ -123,6 +127,7 @@ def unalias_name(message, user_name, alias_name=None):
 
 
 @respond_to(r'^alias\s+help$')
+@call_when_sls_haro_not_installed
 def show_help_alias_commands(message):
     """Userコマンドのhelpを表示
 

--- a/src/haro/plugins/amesh.py
+++ b/src/haro/plugins/amesh.py
@@ -8,6 +8,7 @@ from datetime import datetime
 import requests
 from PIL import Image
 from haro.botmessage import botsend
+from haro.decorators import call_when_sls_haro_not_installed
 from slackbot.bot import respond_to
 
 HELP = """
@@ -32,6 +33,7 @@ def _get_image(url):
 
 
 @respond_to("^amesh$")
+@call_when_sls_haro_not_installed
 def amesh(message):
 
     # ameshでは5分ごとにデータが作成されるため、桁を揃えてからリクエストしたい

--- a/src/haro/plugins/create.py
+++ b/src/haro/plugins/create.py
@@ -9,6 +9,7 @@ from haro.arg_validator import (
     register_arg_validator,
 )
 from haro.botmessage import botsend, webapisend
+from haro.decorators import call_when_sls_haro_not_installed
 from haro.plugins.create_models import CreateCommand, Term
 
 HELP = """
@@ -147,6 +148,7 @@ class ReturnTermCommandValidator(BaseCommandValidator):
 
 
 @respond_to(r'^create\s+add\s+(\S+)$')
+@call_when_sls_haro_not_installed
 @register_arg_validator(AddCommandValidator)
 def add_command(message, command_name):
     """新たにコマンドを作成する
@@ -162,6 +164,7 @@ def add_command(message, command_name):
 
 
 @respond_to(r'^create\s+del\s+(\S+)$')
+@call_when_sls_haro_not_installed
 @register_arg_validator(DelCommandValidator, ['command'])
 def del_command(message, command_name, command=None):
     """コマンドを削除する
@@ -176,6 +179,7 @@ def del_command(message, command_name, command=None):
 
 
 @respond_to(r'^(\S+)$')
+@call_when_sls_haro_not_installed
 @register_arg_validator(ReturnTermCommandValidator, ['command'])
 def return_term(message, command_name, command=None):
     """コマンドに登録されている語録をランダムに返す
@@ -194,6 +198,7 @@ def return_term(message, command_name, command=None):
 
 
 @respond_to(r'^(\S+)\s+(.+)')
+@call_when_sls_haro_not_installed
 @register_arg_validator(RunCommandValidator, ['command'])
 def run_command(message, command_name, params, command=None):
     """登録したコマンドに対して各種操作を行う
@@ -347,6 +352,7 @@ def add_term(message, command, word):
 
 
 @respond_to(r'^create\s+help$')
+@call_when_sls_haro_not_installed
 def show_help_create_commands(message):
     """createコマンドのhelpを表示
 

--- a/src/haro/plugins/kudo.py
+++ b/src/haro/plugins/kudo.py
@@ -2,6 +2,7 @@ from slackbot.bot import respond_to, listen_to
 from sqlalchemy import func
 from db import Session
 from haro.botmessage import botsend
+from haro.decorators import call_when_sls_haro_not_installed
 from haro.plugins.kudo_models import KudoHistory
 from haro.slack import get_user_name
 
@@ -12,6 +13,7 @@ HELP = """
 
 
 @listen_to(r'^(.*)\s*(?<!\+)\+\+$')
+@call_when_sls_haro_not_installed
 def update_kudo(message, names):
     """ 指定された名前に対して ++ する
 
@@ -59,6 +61,7 @@ def update_kudo(message, names):
 
 
 @respond_to(r'^kudo\s+help$')
+@call_when_sls_haro_not_installed
 def show_help_alias_commands(message):
     """Kudoコマンドのhelpを表示
 

--- a/src/haro/plugins/misc.py
+++ b/src/haro/plugins/misc.py
@@ -2,9 +2,11 @@ import random
 
 from slackbot.bot import respond_to
 from haro.botmessage import botsend
+from haro.decorators import call_when_sls_haro_not_installed
 
 
 @respond_to(r'^shuffle\s+(.*)')
+@call_when_sls_haro_not_installed
 def shuffle(message, words):
     """指定したキーワードをシャッフルして返す
     """
@@ -17,6 +19,7 @@ def shuffle(message, words):
 
 
 @respond_to(r'^choice\s+(.*)')
+@call_when_sls_haro_not_installed
 def choice(message, words):
     """指定したキーワードから一つを選んで返す
     """

--- a/src/haro/plugins/random.py
+++ b/src/haro/plugins/random.py
@@ -4,7 +4,6 @@ import random
 from slackbot.bot import respond_to
 from slackbot import settings
 import slacker
-
 from haro.botmessage import botsend
 from haro.decorators import call_when_sls_haro_not_installed
 

--- a/src/haro/plugins/random.py
+++ b/src/haro/plugins/random.py
@@ -4,7 +4,9 @@ import random
 from slackbot.bot import respond_to
 from slackbot import settings
 import slacker
+
 from haro.botmessage import botsend
+from haro.decorators import call_when_sls_haro_not_installed
 
 
 HELP = '''
@@ -18,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 @respond_to('^random$')
 @respond_to(r'^random\s+(active|help)$')
+@call_when_sls_haro_not_installed
 def random_command(message, subcommand=None):
     """
     チャンネルにいるメンバーからランダムに一人を選んで返す

--- a/src/haro/plugins/uranai.py
+++ b/src/haro/plugins/uranai.py
@@ -3,6 +3,7 @@ import datetime
 import requests
 from slackbot.bot import respond_to
 from haro.botmessage import botsend
+from haro.decorators import call_when_sls_haro_not_installed
 
 
 def star(n):
@@ -30,6 +31,7 @@ def uranai(birthday):
 
 
 @respond_to(r'^uranai\s+(\d{4})$')
+@call_when_sls_haro_not_installed
 def show_uranai_commands(message, birthday):
     """Uranaiコマンドの結果を表示
 


### PR DESCRIPTION
## Issue

- #222

## 対応内容

- 前段として、チャンネルに旧haroと新haroのアプリがどちらも追加されているときは、旧haro側のコマンド実行を中断してくれるデコレータを以下PRで用意した
  - #223 
- すでに新haroに移植済のコマンドに上記のデコレータを付与して、新haro側のコマンドが優先して実行されるようにしたい
  - [移植済なコマンドはこちら](https://github.com/beproud/beproudbot-sls/blob/main/src/handlers/event.py#L13-L23)
## このレビューで確認してほしい点

- [x] 新haro移植済のコマンドすべてにデコレータを付与しているか

## レビューチェックリスト

- [x] C2 体を表す名前の公理：あらかじめ決められている以外の汎用的な名前のモジュールを作らない
- [x] C3 汎用名のモジュール内に長々と具体的処理を書かない
- [x] C4 単純な処理の長さで分割しない
- [x] C5 引数の数を減らす
- [x] C6 パッケージ間で共通した定数を作らない
- [x] C7 継承の利用を最小限にする
- [x] C8 親クラスのテストを子クラスでも実行すること
- [x] C9 オーバーライドを減らす
- [x] C10 継承やオーバーライドを明示する
