### PR TITLE
環境変数追加: fix for #231

### DIFF
--- a/env.sample
+++ b/env.sample
@@ -19,6 +19,7 @@ PROJECT_ROOT=/home/haro/beproudbot
 
 # opentelemetry
 # OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317
+# OTEL_EXPORTER_OTLP_INSECURE=true
 
 # ansible
 # ENVIRONMENT_FILE_PATH=/home/haro/beproudbot/.env


### PR DESCRIPTION
チケットURL

- #231 の修正

やったこと

- 本番haroサーバーの `/home/haro/beproudbot/.env` に環境変数 `OTEL_EXPORTER_OTLP_INSECURE=true` を追加し、 `sudo systemctl restart haro` でサービスを再起動した

このレビューで確認してほしい点

- 再デプロイが不要なこと