### PR TITLE
#238 redmineコマンドに `@call_when_sls_haro_not_installed` デコレータを付加する

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,5 +1,9 @@
 Unreleased
 ----------
+
+
+Release Notes - 2023-03-16
+--------------------------
 - [#238] redmineコマンドに `@call_when_sls_haro_not_installed` デコレータを付加する
 
 Release Notes - 2023-02-16

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,7 @@
+Unreleased
+----------
+- [#238] redmineコマンドに `@call_when_sls_haro_not_installed` デコレータを付加する
+
 Release Notes - 2023-02-16
 --------------------------
 - [#241] haro2で追加したテーブルをdbに反映させる

--- a/src/haro/plugins/redmine.py
+++ b/src/haro/plugins/redmine.py
@@ -4,6 +4,7 @@ from slackbot.bot import listen_to, respond_to
 from slackbot_settings import REDMINE_URL
 from db import Session
 from haro.botmessage import botsend
+from haro.decorators import call_when_sls_haro_not_installed
 from haro.plugins.redmine_models import RedmineUser, ProjectChannel
 
 RESPONSE_ERROR = 'Redmineにアクセスできませんでした。'
@@ -65,6 +66,7 @@ def user_from_message(message, session):
 
 
 @respond_to(r'^redmine\s+help$')
+@call_when_sls_haro_not_installed
 def show_help_redmine_commands(message):
     """Redmineコマンドのhelpを表示
     """
@@ -72,6 +74,7 @@ def show_help_redmine_commands(message):
 
 
 @listen_to(r'issues\/(\d{2,}\#note\-\d+)|issues\/(\d{2,})|[^a-zA-Z/`\n`][t](\d{2,})|^t(\d{2,})')
+@call_when_sls_haro_not_installed
 def show_ticket_information(message, *ticket_ids):  # NOQA: R701, C901
     """Redmineのチケット情報を参照する.
 
@@ -152,6 +155,7 @@ def show_ticket_information(message, *ticket_ids):  # NOQA: R701, C901
 
 
 @respond_to(r'^redmine\s+key\s+(\S+)$')
+@call_when_sls_haro_not_installed
 def register_key(message, api_key):
     s = Session()
 
@@ -176,6 +180,7 @@ def register_key(message, api_key):
 
 
 @respond_to(r'^redmine\s+add\s+([a-zA-Z0-9_-]+)$')
+@call_when_sls_haro_not_installed
 def register_room(message, project_identifier):
     """RedmineのプロジェクトとSlackチャンネルを繋ぐ.
 
@@ -210,6 +215,7 @@ def register_room(message, project_identifier):
 
 
 @respond_to(r'^redmine\s+remove\s+([a-zA-Z0-9_-]+)$')
+@call_when_sls_haro_not_installed
 def unregister_room(message, project_identifier):
     s = Session()
 


### PR DESCRIPTION
チケットURL

- #238

このレビューで確認してほしい点

- [ ] デコレータを付与するコマンドが正しいか

レビューチェックリスト

- [ ] C2 体を表す名前の公理：あらかじめ決められている以外の汎用的な名前のモジュールを作らない
- [ ] C3 汎用名のモジュール内に長々と具体的処理を書かない
- [ ] C4 単純な処理の長さで分割しない
- [ ] C5 引数の数を減らす
- [ ] C6 パッケージ間で共通した定数を作らない
- [ ] C7 継承の利用を最小限にする
- [ ] C8 親クラスのテストを子クラスでも実行すること
- [ ] C9 オーバーライドを減らす
- [ ] C10 継承やオーバーライドを明示する
